### PR TITLE
Add libmount to the freedesktop platform

### DIFF
--- a/meta-freedesktop/recipes-core/tasks/task-freedesktop-contents-platform.bb
+++ b/meta-freedesktop/recipes-core/tasks/task-freedesktop-contents-platform.bb
@@ -29,6 +29,7 @@ RDEPENDS_${PN} += "\
          libatomic-ops \
          popt \
          util-linux-libuuid \
+         util-linux-libmount \
          libpcre \
          libcomerr \
          \


### PR DESCRIPTION
GLib will now link against libmount if it is present, and for
some reason, it is present in the sdk. Not having it in the runtime
is bad, since GLib is built against the sdk.