### PR TITLE
add perl-misc for pod2man

### DIFF
--- a/meta-freedesktop/recipes-core/tasks/task-freedesktop-contents-sdk.bb
+++ b/meta-freedesktop/recipes-core/tasks/task-freedesktop-contents-sdk.bb
@@ -71,6 +71,7 @@ RDEPENDS_${PN} += "     \
          \
          libxml-parser-perl \
          libxml-parser-perl-dev \
+         perl-misc \
          perl-modules \
          python-dev \
          python-modules \


### PR DESCRIPTION
Include pod2man in the SDK, which is commonly used for generating manpages for command line tools. This seems preferable to generating un-necessary friction for packaging things like dependent libraries that happen to come with some binaries.