### PR TITLE
add perl-doc to sdk

### DIFF
--- a/meta-freedesktop/recipes-core/tasks/task-freedesktop-contents-sdk.bb
+++ b/meta-freedesktop/recipes-core/tasks/task-freedesktop-contents-sdk.bb
@@ -73,6 +73,7 @@ RDEPENDS_${PN} += "     \
          \
          libxml-parser-perl \
          libxml-parser-perl-dev \
+         perl-doc \
          perl-misc \
          perl-modules \
          python-dev \


### PR DESCRIPTION
Contains stuff like "xsubpp" which is needed to build C perl modules.