### PR TITLE
python: Enable ucs4 unicode mode

### DIFF
--- a/meta-freedesktop/recipes-devtools/python/python_2.7.12.bbappend
+++ b/meta-freedesktop/recipes-devtools/python/python_2.7.12.bbappend
@@ -6,3 +6,5 @@ SRC_URI += "\
 do_install_append() {
         install -m 0755 ${WORKDIR}/usercustomize.py ${D}${libdir}/python2.7/usercustomize.py
 }
+
+EXTRA_OECONF += "--enable-unicode=ucs4"


### PR DESCRIPTION
This matches what basically all distros do. However, it is
an ABI break, so we will have to update all known apps that may
link to python.

See:
  https://github.com/flatpak/freedesktop-sdk-base/issues/18
For tracking the ABI change